### PR TITLE
MoreMcmeta Compatibility Fix (soir20/MoreMcmeta#3)

### DIFF
--- a/src/main/java/me/pepperbell/continuity/client/mixin/ReloadableResourceManagerImplMixin.java
+++ b/src/main/java/me/pepperbell/continuity/client/mixin/ReloadableResourceManagerImplMixin.java
@@ -23,7 +23,7 @@ import net.minecraft.util.Unit;
 @Mixin(ReloadableResourceManagerImpl.class)
 public class ReloadableResourceManagerImplMixin implements ReloadableResourceManagerImplExtension {
 	@Unique
-	private final Map<Identifier, Identifier> redirects = new Object2ObjectOpenHashMap<>();
+	private static final Map<Identifier, Identifier> redirects = new Object2ObjectOpenHashMap<>();
 
 	@Override
 	public void addRedirect(Identifier from, Identifier to) {


### PR DESCRIPTION
Good afternoon.

I'm not sure if you saw my message over at soir20/MoreMcmeta#3 (don't know how well GitHub mentions work). To summarize:

- MoreMcmeta uses a resource manager wrapper, `SizeSwappingResourceManager`, that delegates to the original manager. Because the Map inside Continuity's `ReloadableResourceManagerImplMixin` is an instance field, the delegate that actually searches for the resources never receives the redirects.
- The fixes for this compatibility issue on MoreMcmeta's end require coremodding or are fragile.
- I might have to revisit this problem if a similar issue comes up with another mod, but I haven't identified other mods that I believe would cause the same problem through GitHub search. And that wouldn't affect Continuity anyway.

I've simply changed the redirect map in `ReloadableResourceManagerImplMixin` to be `static` so that all resource managers share the redirects--this seemed like the most conservative fix to avoid breaking your code.

I've tested this change with both mods on 1.17. I can see continuous glass and glass panes (w/ culling fix enabled) and animated textures. (There isn't a 1.18 version of MoreMcmeta out yet.)