### PR TITLE
Port to 1.21.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,10 @@ org.gradle.jvmargs = -Xmx1G
 org.gradle.parallel = true
 
 # Fabric Properties
-loom_version = 1.6.11
-minecraft_version = 1.21
-yarn_mappings = 1.21+build.1
-loader_version = 0.15.11
+loom_version = 1.8.9
+minecraft_version = 1.21.3
+yarn_mappings = 1.21.3+build.2
+loader_version = 0.16.7
 
 # Mod Properties
 mod_version = 3.0.0-beta.6
@@ -15,5 +15,5 @@ maven_group = me.pepperbell
 archives_base_name = continuity
 
 # Dependencies
-fabric_version = 0.100.1+1.21
-modmenu_version = 11.0.0-beta.1
+fabric_version = 0.107.0+1.21.3
+modmenu_version = 12.0.0-beta.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/me/pepperbell/continuity/client/mixin/BakerImplMixin.java
+++ b/src/main/java/me/pepperbell/continuity/client/mixin/BakerImplMixin.java
@@ -1,0 +1,24 @@
+package me.pepperbell.continuity.client.mixin;
+
+import me.pepperbell.continuity.client.mixinterface.ModelBakerExtension;
+import me.pepperbell.continuity.client.resource.ModelWrappingHandler;
+import net.minecraft.client.render.model.ModelBaker;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(targets = { "net/minecraft/client/render/model/ModelBaker$BakerImpl"})
+public class BakerImplMixin implements ModelBakerExtension {
+    @Shadow @Final ModelBaker field_40571;
+
+    @Override
+    public @Nullable ModelWrappingHandler continuity$getModelWrappingHandler() {
+        return ((ModelBakerExtension)this.field_40571).continuity$getModelWrappingHandler();
+    }
+
+    @Override
+    public void continuity$setModelWrappingHandler(@Nullable ModelWrappingHandler handler) {
+        ((ModelBakerExtension)this.field_40571).continuity$setModelWrappingHandler(handler);
+    }
+}

--- a/src/main/java/me/pepperbell/continuity/client/mixin/FallingBlockEntityRendererMixin.java
+++ b/src/main/java/me/pepperbell/continuity/client/mixin/FallingBlockEntityRendererMixin.java
@@ -10,14 +10,14 @@ import net.minecraft.client.render.entity.FallingBlockEntityRenderer;
 
 @Mixin(FallingBlockEntityRenderer.class)
 abstract class FallingBlockEntityRendererMixin {
-	@Inject(method = "render(Lnet/minecraft/entity/FallingBlockEntity;FFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/BlockModelRenderer;render(Lnet/minecraft/world/BlockRenderView;Lnet/minecraft/client/render/model/BakedModel;Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumer;ZLnet/minecraft/util/math/random/Random;JI)V"))
+	@Inject(method = "render(Lnet/minecraft/client/render/entity/state/FallingBlockEntityRenderState;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/BlockModelRenderer;render(Lnet/minecraft/world/BlockRenderView;Lnet/minecraft/client/render/model/BakedModel;Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumer;ZLnet/minecraft/util/math/random/Random;JI)V"))
 	private void continuity$beforeRenderModel(CallbackInfo ci) {
 		ContinuityFeatureStates states = ContinuityFeatureStates.get();
 		states.getConnectedTexturesState().disable();
 		states.getEmissiveTexturesState().disable();
 	}
 
-	@Inject(method = "render(Lnet/minecraft/entity/FallingBlockEntity;FFLnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/BlockModelRenderer;render(Lnet/minecraft/world/BlockRenderView;Lnet/minecraft/client/render/model/BakedModel;Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumer;ZLnet/minecraft/util/math/random/Random;JI)V", shift = At.Shift.AFTER))
+	@Inject(method = "render(Lnet/minecraft/client/render/entity/state/FallingBlockEntityRenderState;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumerProvider;I)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/block/BlockModelRenderer;render(Lnet/minecraft/world/BlockRenderView;Lnet/minecraft/client/render/model/BakedModel;Lnet/minecraft/block/BlockState;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/client/render/VertexConsumer;ZLnet/minecraft/util/math/random/Random;JI)V", shift = At.Shift.AFTER))
 	private void continuity$afterRenderModel(CallbackInfo ci) {
 		ContinuityFeatureStates states = ContinuityFeatureStates.get();
 		states.getConnectedTexturesState().enable();

--- a/src/main/java/me/pepperbell/continuity/client/mixin/ModelBakerMixin.java
+++ b/src/main/java/me/pepperbell/continuity/client/mixin/ModelBakerMixin.java
@@ -1,15 +1,15 @@
 package me.pepperbell.continuity.client.mixin;
 
+import net.minecraft.client.render.model.ModelBaker;
 import org.jetbrains.annotations.Nullable;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Unique;
 
-import me.pepperbell.continuity.client.mixinterface.ModelLoaderExtension;
+import me.pepperbell.continuity.client.mixinterface.ModelBakerExtension;
 import me.pepperbell.continuity.client.resource.ModelWrappingHandler;
-import net.minecraft.client.render.model.ModelLoader;
 
-@Mixin(ModelLoader.class)
-abstract class ModelLoaderMixin implements ModelLoaderExtension {
+@Mixin(ModelBaker.class)
+abstract class ModelBakerMixin implements ModelBakerExtension {
 	@Unique
 	@Nullable
 	private ModelWrappingHandler continuity$modelWrappingHandler;

--- a/src/main/java/me/pepperbell/continuity/client/mixinterface/ModelBakerExtension.java
+++ b/src/main/java/me/pepperbell/continuity/client/mixinterface/ModelBakerExtension.java
@@ -4,7 +4,7 @@ import org.jetbrains.annotations.Nullable;
 
 import me.pepperbell.continuity.client.resource.ModelWrappingHandler;
 
-public interface ModelLoaderExtension {
+public interface ModelBakerExtension {
 	@Nullable
 	ModelWrappingHandler continuity$getModelWrappingHandler();
 

--- a/src/main/java/me/pepperbell/continuity/client/processor/overlay/StandardOverlayQuadProcessor.java
+++ b/src/main/java/me/pepperbell/continuity/client/processor/overlay/StandardOverlayQuadProcessor.java
@@ -126,7 +126,7 @@ public class StandardOverlayQuadProcessor extends AbstractQuadProcessor {
 		BlockState otherAppearanceState = otherState.getAppearance(blockView, mutablePos, lightFace, state, pos);
 		if (appliesOverlay(otherAppearanceState, otherState, mutablePos, blockView, appearanceState, state, pos, lightFace, quadSprite)) {
 			mutablePos.move(lightFace);
-			return !blockView.getBlockState(mutablePos).isOpaqueFullCube(blockView, mutablePos);
+			return !blockView.getBlockState(mutablePos).isOpaqueFullCube();
 		}
 		return false;
 	}
@@ -219,7 +219,7 @@ public class StandardOverlayQuadProcessor extends AbstractQuadProcessor {
 
 		mutablePos.set(pos, directions[0]).move(lightFace);
 		BlockState appearanceState0;
-		if (!blockView.getBlockState(mutablePos).isOpaqueFullCube(blockView, mutablePos)) {
+		if (!blockView.getBlockState(mutablePos).isOpaqueFullCube()) {
 			mutablePos.set(pos, directions[0]);
 			BlockState state0 = blockView.getBlockState(mutablePos);
 			appearanceState0 = state0.getAppearance(blockView, mutablePos, lightFace, state, pos);
@@ -232,7 +232,7 @@ public class StandardOverlayQuadProcessor extends AbstractQuadProcessor {
 
 		mutablePos.set(pos, directions[1]).move(lightFace);
 		BlockState appearanceState1;
-		if (!blockView.getBlockState(mutablePos).isOpaqueFullCube(blockView, mutablePos)) {
+		if (!blockView.getBlockState(mutablePos).isOpaqueFullCube()) {
 			mutablePos.set(pos, directions[1]);
 			BlockState state1 = blockView.getBlockState(mutablePos);
 			appearanceState1 = state1.getAppearance(blockView, mutablePos, lightFace, state, pos);
@@ -245,7 +245,7 @@ public class StandardOverlayQuadProcessor extends AbstractQuadProcessor {
 
 		mutablePos.set(pos, directions[2]).move(lightFace);
 		BlockState appearanceState2;
-		if (!blockView.getBlockState(mutablePos).isOpaqueFullCube(blockView, mutablePos)) {
+		if (!blockView.getBlockState(mutablePos).isOpaqueFullCube()) {
 			mutablePos.set(pos, directions[2]);
 			BlockState state2 = blockView.getBlockState(mutablePos);
 			appearanceState2 = state2.getAppearance(blockView, mutablePos, lightFace, state, pos);
@@ -258,7 +258,7 @@ public class StandardOverlayQuadProcessor extends AbstractQuadProcessor {
 
 		mutablePos.set(pos, directions[3]).move(lightFace);
 		BlockState appearanceState3;
-		if (!blockView.getBlockState(mutablePos).isOpaqueFullCube(blockView, mutablePos)) {
+		if (!blockView.getBlockState(mutablePos).isOpaqueFullCube()) {
 			mutablePos.set(pos, directions[3]);
 			BlockState state3 = blockView.getBlockState(mutablePos);
 			appearanceState3 = state3.getAppearance(blockView, mutablePos, lightFace, state, pos);

--- a/src/main/java/me/pepperbell/continuity/client/resource/BakedModelManagerReloadExtension.java
+++ b/src/main/java/me/pepperbell/continuity/client/resource/BakedModelManagerReloadExtension.java
@@ -7,12 +7,12 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import net.minecraft.client.render.model.ModelBaker;
 import org.jetbrains.annotations.Nullable;
 
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
-import me.pepperbell.continuity.client.mixinterface.ModelLoaderExtension;
+import me.pepperbell.continuity.client.mixinterface.ModelBakerExtension;
 import me.pepperbell.continuity.client.model.QuadProcessors;
-import net.minecraft.client.render.model.ModelLoader;
 import net.minecraft.client.render.model.SpriteAtlasManager;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.client.texture.SpriteAtlasTexture;
@@ -39,7 +39,7 @@ public class BakedModelManagerReloadExtension {
 		SpriteLoaderLoadContext.THREAD_LOCAL.set(null);
 	}
 
-	public void beforeBaking(Map<Identifier, SpriteAtlasManager.AtlasPreparation> preparations, ModelLoader modelLoader) {
+	public void beforeBaking(Map<Identifier, SpriteAtlasManager.AtlasPreparation> preparations, ModelBaker modelBaker) {
 		CtmPropertiesLoader.LoadingResult result = ctmLoadingResultFuture.join();
 
 		List<QuadProcessors.ProcessorHolder> processorHolders = result.createProcessorHolders(spriteId -> {
@@ -54,7 +54,7 @@ public class BakedModelManagerReloadExtension {
 		this.processorHolders = processorHolders;
 
 		ModelWrappingHandler wrappingHandler = ModelWrappingHandler.create(!processorHolders.isEmpty(), wrapEmissiveModels.get());
-		((ModelLoaderExtension) modelLoader).continuity$setModelWrappingHandler(wrappingHandler);
+		((ModelBakerExtension) modelBaker).continuity$setModelWrappingHandler(wrappingHandler);
 	}
 
 	public void apply() {

--- a/src/main/java/me/pepperbell/continuity/client/resource/CustomBlockLayers.java
+++ b/src/main/java/me/pepperbell/continuity/client/resource/CustomBlockLayers.java
@@ -42,7 +42,7 @@ public final class CustomBlockLayers {
 	@Nullable
 	public static RenderLayer getLayer(BlockState state) {
 		if (!disableSolidCheck) {
-			if (state.isOpaqueFullCube(EmptyBlockView.INSTANCE, BlockPos.ORIGIN)) {
+			if (state.isOpaqueFullCube()) {
 				return null;
 			}
 		}

--- a/src/main/java/me/pepperbell/continuity/client/resource/ModelWrappingHandler.java
+++ b/src/main/java/me/pepperbell/continuity/client/resource/ModelWrappingHandler.java
@@ -1,12 +1,13 @@
 package me.pepperbell.continuity.client.resource;
 
+import net.minecraft.client.render.model.MissingModel;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.UnknownNullability;
 
 import com.google.common.collect.ImmutableMap;
 
-import me.pepperbell.continuity.client.mixinterface.ModelLoaderExtension;
+import me.pepperbell.continuity.client.mixinterface.ModelBakerExtension;
 import me.pepperbell.continuity.client.model.CtmBakedModel;
 import me.pepperbell.continuity.client.model.EmissiveBakedModel;
 import net.fabricmc.fabric.api.client.model.loading.v1.ModelLoadingPlugin;
@@ -15,7 +16,6 @@ import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.client.render.block.BlockModels;
 import net.minecraft.client.render.model.BakedModel;
-import net.minecraft.client.render.model.ModelLoader;
 import net.minecraft.client.util.ModelIdentifier;
 import net.minecraft.registry.Registries;
 import net.minecraft.util.Identifier;
@@ -53,7 +53,7 @@ public class ModelWrappingHandler {
 	}
 
 	public BakedModel wrap(@Nullable BakedModel model, @UnknownNullability Identifier resourceId, @UnknownNullability ModelIdentifier topLevelId) {
-		if (model != null && !model.isBuiltin() && (resourceId == null || !resourceId.equals(ModelLoader.MISSING_ID))) {
+		if (model != null && !model.isBuiltin() && (resourceId == null || !resourceId.equals(MissingModel.ID))) {
 			if (wrapCtm) {
 				if (topLevelId != null) {
 					BlockState state = blockStateModelIds.get(topLevelId);
@@ -73,8 +73,10 @@ public class ModelWrappingHandler {
 	public static void init() {
 		ModelLoadingPlugin.register(pluginCtx -> {
 			pluginCtx.modifyModelAfterBake().register(ModelModifier.WRAP_LAST_PHASE, (model, ctx) -> {
-				ModelLoader modelLoader = ctx.loader();
-				ModelWrappingHandler wrappingHandler = ((ModelLoaderExtension) modelLoader).continuity$getModelWrappingHandler();
+				ModelWrappingHandler wrappingHandler = null;
+				if (ctx.baker() instanceof ModelBakerExtension extension) {
+					wrappingHandler = extension.continuity$getModelWrappingHandler();
+				}
 				if (wrappingHandler != null) {
 					return wrappingHandler.wrap(model, ctx.resourceId(), ctx.topLevelId());
 				}

--- a/src/main/java/me/pepperbell/continuity/client/util/biome/BiomeHolderManager.java
+++ b/src/main/java/me/pepperbell/continuity/client/util/biome/BiomeHolderManager.java
@@ -39,7 +39,7 @@ public final class BiomeHolderManager {
 		}
 
 		Map<Identifier, Identifier> compactIdMap = new Object2ObjectOpenHashMap<>();
-		Registry<Biome> biomeRegistry = registryManager.get(RegistryKeys.BIOME);
+		Registry<Biome> biomeRegistry = registryManager.getOrThrow(RegistryKeys.BIOME);
 		for (Identifier id : biomeRegistry.getIds()) {
 			String path = id.getPath();
 			String compactPath = path.replace("_", "");

--- a/src/main/resources/continuity.mixins.json
+++ b/src/main/resources/continuity.mixins.json
@@ -6,11 +6,12 @@
   "client": [
     "AtlasLoaderMixin",
     "BakedModelManagerMixin",
+    "BakerImplMixin",
     "BlockModelsMixin",
     "FallingBlockEntityRendererMixin",
     "IdentifierMixin",
     "LifecycledResourceManagerImplMixin",
-    "ModelLoaderMixin",
+    "ModelBakerMixin",
     "NamespaceResourceManagerMixin",
     "PistonBlockEntityRendererMixin",
     "ReloadableResourceManagerImplAccessor",


### PR DESCRIPTION
Not very satisfied with the solution I used for storing the `ModelWrappingHandler` (stored it on `ModelBaker`, and added a passthrough implementation to `BakerImpl`). Everything else is pretty straightforward.

Ported this mostly for my own use; feel free to close if you've already done the work, I won't be offended.